### PR TITLE
Fix bug compiling with spaces in project path

### DIFF
--- a/Makefile.tpl
+++ b/Makefile.tpl
@@ -457,7 +457,7 @@ $(OBJDIR)/%.elf: $(OBJ)
 $(OBJDIR)/%.o : %.c
 	@echo
 	@echo $(MSG_COMPILING) $<
-	$(CC) -c $(ALL_CFLAGS) $(abspath $<) -o $@ 
+	$(CC) -c $(ALL_CFLAGS) "$(abspath $<)" -o $@ 
 
 
 # Compile: create assembler files from C source files.


### PR DESCRIPTION
Fixes a bug where compilation will fail due to spaces in the path to the project (including the project name). Solved by embedding abspath in quotes.
